### PR TITLE
Fix missing ref exception

### DIFF
--- a/Space-Zoologist/Assets/DialogueEditor/Assets/Scripts/UI/ConversationManager.cs
+++ b/Space-Zoologist/Assets/DialogueEditor/Assets/Scripts/UI/ConversationManager.cs
@@ -690,6 +690,7 @@ namespace DialogueEditor
             OptionsPanel.gameObject.SetActive(false);
             NpcIcon.gameObject.SetActive(false);
             SetState(eState.Off);
+            gameObject.SetActive(false);
 #if UNITY_EDITOR
             // Debug.Log("[ConversationManager]: Conversation UI off.");
 #endif

--- a/Space-Zoologist/Assets/Scripts/Managers/Dialogue/DialogueManager.cs
+++ b/Space-Zoologist/Assets/Scripts/Managers/Dialogue/DialogueManager.cs
@@ -58,7 +58,9 @@ public class DialogueManager : MonoBehaviour
         else
         {
             ContinueSpeech = false;
-            ConversationManagerGameObject.SetActive(false);
+            // inconsistent access to the gameObject causes missing ref exception
+            // after scene transitions. Moved to ConversationManager.TurnOffUI()
+            //ConversationManagerGameObject.SetActive(false);
             GameManager.Instance.m_menuManager.ToggleUI(true);
         }
     }


### PR DESCRIPTION
Disabling conversation manager in ConversationManager.TurnOffUI() rather than DialogueManager.ConversationEnded().

Reason: Inconsistent access through callbacks to DialogueManager.ConversationManagerGameObject caused missing ref exception after scene transitions.

![image](https://user-images.githubusercontent.com/24749416/137872797-fc67a796-edc0-4beb-942d-caff01f3750c.png)
