### PR TITLE
NeedsCache now keeps track of when the PopulationCache is dirty or th…

### DIFF
--- a/Space-Zoologist/Assets/Animals/Patterns/Scripts/BehaviorPattern.cs
+++ b/Space-Zoologist/Assets/Animals/Patterns/Scripts/BehaviorPattern.cs
@@ -106,7 +106,10 @@ public class BehaviorPattern : MonoBehaviour
     protected virtual void ExitPattern(GameObject animal, bool callCallback = true)
     {
         animal.GetComponent<AnimalBehaviorManager>().activeBehaviorPattern = null;
-        StepCompletedCallBack callback = AnimalsToAnimalData[animal].callback;
+        StepCompletedCallBack callback = 
+            AnimalsToAnimalData.ContainsKey(animal) ? 
+            AnimalsToAnimalData[animal].callback : null;
+
         AnimalsToAnimalData.Remove(animal);
         if (callCallback)
         {

--- a/Space-Zoologist/Assets/Prefabs/Dialogue/Level Intros/Level2/Level2E4Intro.prefab
+++ b/Space-Zoologist/Assets/Prefabs/Dialogue/Level Intros/Level2/Level2E4Intro.prefab
@@ -82,6 +82,7 @@ MonoBehaviour:
   - {fileID: 6007554260346152682}
   - {fileID: 7995183552713338283}
   - {fileID: 0}
+  - {fileID: 8175925614809940537}
   Event:
     m_PersistentCalls:
       m_Calls: []
@@ -104,6 +105,7 @@ GameObject:
   - component: {fileID: 282234943515039857}
   - component: {fileID: 6007554260346152682}
   - component: {fileID: 7995183552713338283}
+  - component: {fileID: 8175925614809940537}
   m_Layer: 0
   m_Name: ConversationEventInfo
   m_TagString: Untagged
@@ -309,6 +311,25 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   NodeID: 2
+  Event:
+    m_PersistentCalls:
+      m_Calls: []
+  TMPFont: {fileID: 0}
+  Icon: {fileID: 0}
+  Audio: {fileID: 0}
+--- !u!114 &8175925614809940537
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6750823513909423511}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00abedce3cdbbba46bf2d86c9518c9f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  NodeID: 4
   Event:
     m_PersistentCalls:
       m_Calls: []

--- a/Space-Zoologist/Assets/ScriptableObjects/Species/Anteater.asset
+++ b/Space-Zoologist/Assets/ScriptableObjects/Species/Anteater.asset
@@ -101,7 +101,7 @@ MonoBehaviour:
             category: 0
             index: 5
       - needs:
-        - needed: 0
+        - needed: 1
           speciesNeedType: 0
           useAsTerrainNeed: 0
           traversibleOnly: 0
@@ -125,19 +125,19 @@ MonoBehaviour:
           id:
             category: 1
             index: 1
-        - needed: 0
+        - needed: 1
           speciesNeedType: 0
           useAsTerrainNeed: 0
           traversibleOnly: 0
           foodNeedType: 0
-          preferred: 0
+          preferred: 1
           useAsWaterNeed: 0
           minimum: 0
           maximum: 0
           id:
             category: 1
             index: 2
-        - needed: 0
+        - needed: 1
           speciesNeedType: 0
           useAsTerrainNeed: 0
           traversibleOnly: 0
@@ -174,10 +174,10 @@ MonoBehaviour:
             category: 1
             index: 5
       - needs:
-        - needed: 0
+        - needed: 1
           speciesNeedType: 0
           useAsTerrainNeed: 0
-          traversibleOnly: 0
+          traversibleOnly: 1
           foodNeedType: 0
           preferred: 0
           useAsWaterNeed: 0
@@ -186,12 +186,12 @@ MonoBehaviour:
           id:
             category: 2
             index: 0
-        - needed: 0
+        - needed: 1
           speciesNeedType: 0
           useAsTerrainNeed: 0
           traversibleOnly: 0
           foodNeedType: 0
-          preferred: 0
+          preferred: 1
           useAsWaterNeed: 0
           minimum: 0
           maximum: 0
@@ -210,10 +210,10 @@ MonoBehaviour:
           id:
             category: 2
             index: 2
-        - needed: 0
+        - needed: 1
           speciesNeedType: 0
           useAsTerrainNeed: 0
-          traversibleOnly: 0
+          traversibleOnly: 1
           foodNeedType: 0
           preferred: 0
           useAsWaterNeed: 0
@@ -222,10 +222,10 @@ MonoBehaviour:
           id:
             category: 2
             index: 3
-        - needed: 0
+        - needed: 1
           speciesNeedType: 0
           useAsTerrainNeed: 0
-          traversibleOnly: 0
+          traversibleOnly: 1
           foodNeedType: 0
           preferred: 0
           useAsWaterNeed: 0
@@ -246,31 +246,31 @@ MonoBehaviour:
           id:
             category: 2
             index: 5
-        - needed: 0
+        - needed: 1
           speciesNeedType: 0
           useAsTerrainNeed: 0
           traversibleOnly: 0
           foodNeedType: 0
           preferred: 0
-          useAsWaterNeed: 0
-          minimum: 0
+          useAsWaterNeed: 1
+          minimum: 0.95
           maximum: 0
           id:
             category: 2
             index: 6
-        - needed: 0
+        - needed: 1
           speciesNeedType: 0
           useAsTerrainNeed: 0
           traversibleOnly: 0
           foodNeedType: 0
           preferred: 0
           useAsWaterNeed: 0
-          minimum: 0
-          maximum: 0
+          minimum: 0.005
+          maximum: 0.02
           id:
             category: 2
             index: 7
-        - needed: 0
+        - needed: 1
           speciesNeedType: 0
           useAsTerrainNeed: 0
           traversibleOnly: 0
@@ -278,7 +278,7 @@ MonoBehaviour:
           preferred: 0
           useAsWaterNeed: 0
           minimum: 0
-          maximum: 0
+          maximum: 0.02
           id:
             category: 2
             index: 8

--- a/Space-Zoologist/Assets/ScriptableObjects/Species/Goat.asset
+++ b/Space-Zoologist/Assets/ScriptableObjects/Species/Goat.asset
@@ -179,7 +179,7 @@ MonoBehaviour:
           useAsTerrainNeed: 0
           traversibleOnly: 0
           foodNeedType: 0
-          preferred: 0
+          preferred: 1
           useAsWaterNeed: 0
           minimum: 0
           maximum: 0
@@ -189,7 +189,7 @@ MonoBehaviour:
         - needed: 1
           speciesNeedType: 0
           useAsTerrainNeed: 0
-          traversibleOnly: 0
+          traversibleOnly: 1
           foodNeedType: 0
           preferred: 1
           useAsWaterNeed: 0
@@ -198,10 +198,10 @@ MonoBehaviour:
           id:
             category: 2
             index: 1
-        - needed: 1
+        - needed: 0
           speciesNeedType: 0
           useAsTerrainNeed: 0
-          traversibleOnly: 1
+          traversibleOnly: 0
           foodNeedType: 0
           preferred: 0
           useAsWaterNeed: 0
@@ -253,8 +253,8 @@ MonoBehaviour:
           foodNeedType: 0
           preferred: 0
           useAsWaterNeed: 1
-          minimum: 0
-          maximum: 0
+          minimum: 0.96
+          maximum: 1
           id:
             category: 2
             index: 6
@@ -265,8 +265,8 @@ MonoBehaviour:
           foodNeedType: 0
           preferred: 0
           useAsWaterNeed: 0
-          minimum: 0
-          maximum: 0
+          minimum: 0.005
+          maximum: 0.02
           id:
             category: 2
             index: 7
@@ -278,7 +278,7 @@ MonoBehaviour:
           preferred: 0
           useAsWaterNeed: 0
           minimum: 0
-          maximum: 0
+          maximum: 1
           id:
             category: 2
             index: 8

--- a/Space-Zoologist/Assets/Scripts/Managers/FoodSourceManager.cs
+++ b/Space-Zoologist/Assets/Scripts/Managers/FoodSourceManager.cs
@@ -52,9 +52,7 @@ public class FoodSourceManager : GridObjectManager
 
         // Invoke the event that occurs when a new food source is created
         EventManager.Instance.InvokeEvent(EventType.NewFoodSource, newFoodSourceGameObject.GetComponent<FoodSource>());
-
-        // NOTE: does the game manager need cache need to be rebuilt now?
-
+        EventManager.Instance.InvokeEvent(EventType.FoodSourceChange, newFoodSourceGameObject.GetComponent<FoodSource>());
         return newFoodSourceGameObject;
     }
 
@@ -70,7 +68,7 @@ public class FoodSourceManager : GridObjectManager
         m_gridSystemReference.RemoveFoodReference(m_gridSystemReference.WorldToCell(foodSource.Position));
         Destroy(foodSource.gameObject);
 
-        // NOTE: does the game manager need cache need to be rebuilt now?
+        EventManager.Instance.InvokeEvent(EventType.FoodSourceChange, null);
     }
 
     /// <summary>

--- a/Space-Zoologist/Assets/Scripts/Managers/GameManager.cs
+++ b/Space-Zoologist/Assets/Scripts/Managers/GameManager.cs
@@ -77,7 +77,7 @@ public class GameManager : MonoBehaviour
     #endregion
 
     #region Need System Variables
-    public NeedCache Needs { get; private set; } = new NeedCache();
+    public NeedCache Needs { get; private set; }
     #endregion
 
     #region Managers
@@ -114,6 +114,7 @@ public class GameManager : MonoBehaviour
         LoadLevelData();
         SetupObjectives();
         InitializeGameStateVariables();
+        Needs = new NeedCache();
         Needs.Rebuild();
     }
 

--- a/Space-Zoologist/Assets/Scripts/Needs/NeedCache.cs
+++ b/Space-Zoologist/Assets/Scripts/Needs/NeedCache.cs
@@ -11,9 +11,55 @@ public class NeedCache
     #region Public Properties
     public NeedAvailabilityCache Availability { get; private set; } = new NeedAvailabilityCache();
     public NeedRatingCache Ratings { get; private set; } = new NeedRatingCache();
+    public bool PopulationCacheDirty { get; private set; } = true;
+    public bool FoodCacheDirty { get; private set; } = true;
     #endregion
 
     #region Public Methods
+
+    public NeedCache()
+    {
+        EventManager.Instance.SubscribeToEvent(EventType.PopulationCountChange, MarkPopulationCacheDirty);
+        EventManager.Instance.SubscribeToEvent(EventType.LiquidChange, MarkFoodCacheDirty);
+        EventManager.Instance.SubscribeToEvent(EventType.FoodSourceChange, MarkFoodCacheDirty);
+        EventManager.Instance.SubscribeToEvent(EventType.TilemapChange, MarkFoodCacheDirty);
+        EventManager.Instance.SubscribeToEvent(EventType.InspectorSelectionChanged, RebuildIfDirty);
+    }
+
+    ~NeedCache()
+    {
+        EventManager.Instance.UnsubscribeToEvent(EventType.PopulationCountChange, MarkPopulationCacheDirty);
+        EventManager.Instance.UnsubscribeToEvent(EventType.LiquidChange, MarkFoodCacheDirty);
+        EventManager.Instance.UnsubscribeToEvent(EventType.FoodSourceChange, MarkFoodCacheDirty);
+        EventManager.Instance.UnsubscribeToEvent(EventType.TilemapChange, MarkFoodCacheDirty);
+        EventManager.Instance.UnsubscribeToEvent(EventType.InspectorSelectionChanged, RebuildIfDirty);
+
+    }
+
+    private void MarkPopulationCacheDirty()
+    {
+        PopulationCacheDirty = true;
+    }
+
+    private void MarkFoodCacheDirty()
+    {
+        FoodCacheDirty = true;
+    }
+
+    public void RebuildIfDirty()
+    {
+        // If food cache is dirty then rebuild both food and population cache
+        if (FoodCacheDirty)
+        {
+            Rebuild();
+        }
+        // If population cache is dirty then rebuild only that
+        else if (PopulationCacheDirty)
+        {
+            RebuildPopulationCache();
+        }
+    }
+
     public void Rebuild()
     {
         // Rebuild the food source first, because population depends on their output,
@@ -27,11 +73,15 @@ public class NeedCache
     {
         Availability.RebuildFoodAvailabilities();
         Ratings.RebuildFoodRatings(Availability);
+        FoodCacheDirty = false;
+        EventManager.Instance.InvokeEvent(EventType.FoodCacheRebuilt, null);
     }
     public void RebuildPopulationCache()
     {
         Availability.RebuildPopulationAvailabilities();
         Ratings.RebuildPopulationRatings(Availability);
+        PopulationCacheDirty = false;
+        EventManager.Instance.InvokeEvent(EventType.PopulationCacheRebuilt, null);
     }
     /// <summary>
     /// Rebuild the cache associated with a single food source

--- a/Space-Zoologist/Assets/Scripts/Plot/LiquidbodyController.cs
+++ b/Space-Zoologist/Assets/Scripts/Plot/LiquidbodyController.cs
@@ -144,6 +144,7 @@ public class LiquidbodyController : MonoBehaviour
             liquidBodies.Remove(originalLiquidbody);
         }
 
+        EventManager.Instance.InvokeEvent(EventType.LiquidChange, pos);
         return true;
     }
 
@@ -227,7 +228,7 @@ public class LiquidbodyController : MonoBehaviour
                 liquidBodies.Add(mergedLiquidbody);
                 break;
         }
-
+        EventManager.Instance.InvokeEvent(EventType.LiquidChange, pos);
         Debug.Log("Liquidbody merge successful.");
         return true;
     }

--- a/Space-Zoologist/Assets/Scripts/Plot/TileDataController.cs
+++ b/Space-Zoologist/Assets/Scripts/Plot/TileDataController.cs
@@ -388,6 +388,7 @@ public class TileDataController : MonoBehaviour
                 tileData.PreviewReplacement(tile);
                 ChangedTiles.Add(tilePosition);
                 ApplyChangeToTilemapTexture(tilePosition);
+                EventManager.Instance.InvokeEvent(EventType.TilemapChange, tilePosition);
             }
         }
     }

--- a/Space-Zoologist/Assets/Scripts/PopulationSystem/Representation/PopulationBehavior.cs
+++ b/Space-Zoologist/Assets/Scripts/PopulationSystem/Representation/PopulationBehavior.cs
@@ -20,6 +20,8 @@ public class PopulationBehavior : ScriptableObject
     }
     public void RemoveCallback(int callbackIndex)
     {
+        if (callbackIndex < 0 || callbackIndex >= behaviorCompleteCallbacks.Count)
+            return;
         behaviorCompleteCallbacks.RemoveAt(callbackIndex);
     }
     /// <summary>

--- a/Space-Zoologist/Assets/Scripts/UI/Inspector/Inspector.cs
+++ b/Space-Zoologist/Assets/Scripts/UI/Inspector/Inspector.cs
@@ -43,6 +43,8 @@ public class Inspector : MonoBehaviour
         //this.HUD.SetActive(true);
         this.UnHighlightAll();
         EventManager.Instance.InvokeEvent(EventType.InspectorToggled, false);
+        EventManager.Instance.UnsubscribeToEvent(EventType.FoodCacheRebuilt, UpdateCurrentDisplay);
+        EventManager.Instance.UnsubscribeToEvent(EventType.PopulationCacheRebuilt, UpdateCurrentDisplay);
         this.IsInInspectorMode = false;
     }
 
@@ -64,6 +66,8 @@ public class Inspector : MonoBehaviour
         GameManager.Instance.m_tileDataController.UpdateAnimalCellGrid();
         //this.HUD.SetActive(false);
         EventManager.Instance.InvokeEvent(EventType.InspectorToggled, true);
+        EventManager.Instance.SubscribeToEvent(EventType.FoodCacheRebuilt, UpdateCurrentDisplay);
+        EventManager.Instance.SubscribeToEvent(EventType.PopulationCacheRebuilt, UpdateCurrentDisplay);
         this.IsInInspectorMode = true;
     }
 
@@ -76,7 +80,7 @@ public class Inspector : MonoBehaviour
         if (this.IsInInspectorMode && Input.GetMouseButtonDown(0) && FindObjectOfType<StoreSection>().SelectedItem == null)
         {
             //Deselect if over UI
-            if(EventSystem.current.IsPointerOverGameObject())
+            if (EventSystem.current.IsPointerOverGameObject())
             {
                 UnHighlightAll();
                 return;
@@ -96,6 +100,11 @@ public class Inspector : MonoBehaviour
         }
     }
 
+    private void AttemptInspect()
+    {
+
+    }
+
     // TODO break this up and refactor
     public void UpdateInspectorValues()
     {
@@ -109,6 +118,7 @@ public class Inspector : MonoBehaviour
         if (cellData == null) { 
             return;
         }
+
         bool somethingSelected = true;
         this.UnHighlightAll();
         if (cellData.Animal)
@@ -143,6 +153,7 @@ public class Inspector : MonoBehaviour
         if (somethingSelected)
         {
             AudioManager.instance.PlayOneShot(SFXType.Observation);
+            EventManager.Instance.InvokeEvent(EventType.InspectorSelectionChanged, true);
             selectionChangedEvent.Invoke();
         }
     }


### PR DESCRIPTION
NeedsCache now keeps track of when the PopulationCache is dirty or the FoodCache is dirty
Rebuilding a cache sets it to Not Dirty
NeedsCache subscribes to various global events in its Constructor, setting certain Caches to dirty when these events are triggered
E.G Setting population cache to dirty listens to PopulationChanged event
The need cache rebuilds its caches as needed (if dirty) when an object is inspected
Functionally, this means that things are rebuilt every time the inspector is used if any changes were made
