### PR TITLE
Fixed issue

### DIFF
--- a/Space-Zoologist/Assets/Scripts/Managers/FoodSourceManager.cs
+++ b/Space-Zoologist/Assets/Scripts/Managers/FoodSourceManager.cs
@@ -68,7 +68,7 @@ public class FoodSourceManager : GridObjectManager
         m_gridSystemReference.RemoveFoodReference(m_gridSystemReference.WorldToCell(foodSource.Position));
         Destroy(foodSource.gameObject);
 
-        EventManager.Instance.InvokeEvent(EventType.FoodSourceChange, null);
+        EventManager.Instance.InvokeEvent(EventType.FoodSourceChange, foodSource);
     }
 
     /// <summary>


### PR DESCRIPTION
When I was updating tile move and other map changing events for the purpose of updating the needscache, I left the event parameter for FoodSourceChange blank, which caused issues
with the logging system that was listening to it.