### PR TITLE
Next Day button no longer disabled when build menu is open

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,4 @@ $RECYCLE.BIN/
 Space-Zoologist/Assets/Scripts/SerializedObjects/SerializedLiquidBody.cs
 Space-Zoologist/Assets/Scripts/SerializedObjects/SerializedLiquidBody.cs.meta
 UI Mockup/*
+Space-Zoologist/.idea/

--- a/Space-Zoologist/.idea/.idea.Space-Zoologist/.idea/workspace.xml
+++ b/Space-Zoologist/.idea/.idea.Space-Zoologist/.idea/workspace.xml
@@ -3,9 +3,8 @@
   <component name="ChangeListManager">
     <list default="true" id="7d906d2e-554a-45de-a110-1b82c5813e7f" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/.idea.Space-Zoologist/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.Space-Zoologist/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Resources/UI/Effects/FadeEffect.mat" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Resources/UI/Effects/FadeEffect.mat" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/Assets/Scenes/MainLevel.unity" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scenes/MainLevel.unity" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Plot/TileDataController.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Plot/TileDataController.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Notebook/UI/NotebookUI.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Notebook/UI/NotebookUI.cs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -15,6 +14,16 @@
   <component name="HighlightingSettingsPerFile">
     <setting file="file://$APPLICATION_CONFIG_DIR$/resharper-host/DecompilerCache/decompiler/5a41d6b7189842eca409fd0b1c3e3dcf17bf78/3c/7e7a2fcb/List`1.cs" root0="SKIP_HIGHLIGHTING" />
     <setting file="file://$APPLICATION_CONFIG_DIR$/resharper-host/DecompilerCache/decompiler/790a43858b4b404fbe02a2b7b4a0d9d615d600/50/c9e047df/Mathf.cs" root0="SKIP_HIGHLIGHTING" />
+    <setting file="mock://C:/Users/arthu/OneDrive/Documents/SpaceZoologist/Space-Zoologist/Assets/Scripts/Managers/GameManager.cs" root0="SKIP_HIGHLIGHTING" />
+    <setting file="mock://C:/Users/arthu/OneDrive/Documents/SpaceZoologist/Space-Zoologist/Assets/Scripts/Managers/GameManager.cs" root0="SKIP_HIGHLIGHTING" />
+    <setting file="mock://C:/Users/arthu/OneDrive/Documents/SpaceZoologist/Space-Zoologist/Assets/Scripts/Managers/GameManager.cs" root0="SKIP_HIGHLIGHTING" />
+    <setting file="mock://C:/Users/arthu/OneDrive/Documents/SpaceZoologist/Space-Zoologist/Assets/Scripts/Managers/GameManager.cs" root0="SKIP_HIGHLIGHTING" />
+    <setting file="mock://C:/Users/arthu/OneDrive/Documents/SpaceZoologist/Space-Zoologist/Assets/Scripts/Notebook/UI/NotebookUI.cs" root0="SKIP_HIGHLIGHTING" />
+    <setting file="mock://C:/Users/arthu/OneDrive/Documents/SpaceZoologist/Space-Zoologist/Assets/Scripts/Notebook/UI/NotebookUI.cs" root0="SKIP_HIGHLIGHTING" />
+    <setting file="mock://C:/Users/arthu/OneDrive/Documents/SpaceZoologist/Space-Zoologist/Assets/Scripts/Notebook/UI/NotebookUI.cs" root0="SKIP_HIGHLIGHTING" />
+    <setting file="mock://C:/Users/arthu/OneDrive/Documents/SpaceZoologist/Space-Zoologist/Assets/Scripts/Notebook/UI/NotebookUI.cs" root0="SKIP_HIGHLIGHTING" />
+    <setting file="mock://C:/Users/arthu/OneDrive/Documents/SpaceZoologist/Space-Zoologist/Assets/Scripts/Notebook/UI/NotebookUI.cs" root0="SKIP_HIGHLIGHTING" />
+    <setting file="mock://C:/Users/arthu/OneDrive/Documents/SpaceZoologist/Space-Zoologist/Assets/Scripts/Notebook/UI/NotebookUI.cs" root0="SKIP_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/Assets/Scripts/UI/LevelEnd/FireworkEffect.cs" root0="FORCE_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/Assets/Scripts/UI/LevelEnd/GenericSpriteAnimWindow.cs" root0="FORCE_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/Assets/Scripts/UI/Utils/SimpleAnimatorPlayer.cs" root0="FORCE_HIGHLIGHTING" />
@@ -100,7 +109,19 @@
       <map>
         <entry key="MAIN">
           <value>
-            <State />
+            <State>
+              <option name="FILTERS">
+                <map>
+                  <entry key="text">
+                    <value>
+                      <list>
+                        <option value="pause" />
+                      </list>
+                    </value>
+                  </entry>
+                </map>
+              </option>
+            </State>
           </value>
         </entry>
       </map>

--- a/Space-Zoologist/.idea/.idea.Space-Zoologist/.idea/workspace.xml
+++ b/Space-Zoologist/.idea/.idea.Space-Zoologist/.idea/workspace.xml
@@ -2,9 +2,10 @@
 <project version="4">
   <component name="ChangeListManager">
     <list default="true" id="7d906d2e-554a-45de-a110-1b82c5813e7f" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Managers/GameOverController.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Managers/GameOverController.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/UI/LevelEnd/FireworkEffect.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/UI/LevelEnd/FireworkEffect.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/UI/LevelEnd/FireworkGen.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/UI/LevelEnd/FireworkGen.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/.idea.Space-Zoologist/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.Space-Zoologist/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Resources/UI/Effects/FadeEffect.mat" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Resources/UI/Effects/FadeEffect.mat" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scenes/MainLevel.unity" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scenes/MainLevel.unity" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Plot/TileDataController.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Plot/TileDataController.cs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -17,6 +18,7 @@
     <setting file="file://$PROJECT_DIR$/Assets/Scripts/UI/LevelEnd/FireworkEffect.cs" root0="FORCE_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/Assets/Scripts/UI/LevelEnd/GenericSpriteAnimWindow.cs" root0="FORCE_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/Assets/Scripts/UI/Utils/SimpleAnimatorPlayer.cs" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/Library/PackageCache/com.unity.ugui@1.0.0/Runtime/UI/Core/Selectable.cs" root0="SKIP_HIGHLIGHTING" />
   </component>
   <component name="MarkdownSettingsMigration">
     <option name="stateVersion" value="1" />

--- a/Space-Zoologist/.idea/.idea.Space-Zoologist/.idea/workspace.xml
+++ b/Space-Zoologist/.idea/.idea.Space-Zoologist/.idea/workspace.xml
@@ -2,9 +2,7 @@
 <project version="4">
   <component name="ChangeListManager">
     <list default="true" id="7d906d2e-554a-45de-a110-1b82c5813e7f" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/.idea.Space-Zoologist/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.Space-Zoologist/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scenes/MainLevel.unity" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scenes/MainLevel.unity" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Notebook/UI/NotebookUI.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Notebook/UI/NotebookUI.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Notebook/UI/DrawingCanvas.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Notebook/UI/DrawingCanvas.cs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/Space-Zoologist/Assets/Resources/UI/Effects/FadeEffect.mat
+++ b/Space-Zoologist/Assets/Resources/UI/Effects/FadeEffect.mat
@@ -34,8 +34,8 @@ Material:
     m_Ints: []
     m_Floats:
     - _ColorMask: 15
-    - _Fade: 1
-    - _Flip: 0
+    - _Fade: 0
+    - _Flip: 1
     - _FlipXY: 0
     - _Stencil: 0
     - _StencilComp: 8

--- a/Space-Zoologist/Assets/Scenes/MainLevel.unity
+++ b/Space-Zoologist/Assets/Scenes/MainLevel.unity
@@ -8904,18 +8904,6 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1570835635}
-        m_TargetAssemblyTypeName: NotebookUI, Assembly-CSharp
-        m_MethodName: SetIsOpen
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
       - m_Target: {fileID: 363993209}
         m_TargetAssemblyTypeName: MenuManager, Assembly-CSharp
         m_MethodName: SetStoreIsOn

--- a/Space-Zoologist/Assets/Scenes/MainLevel.unity
+++ b/Space-Zoologist/Assets/Scenes/MainLevel.unity
@@ -8904,6 +8904,30 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
+      - m_Target: {fileID: 1570835635}
+        m_TargetAssemblyTypeName: NotebookUI, Assembly-CSharp
+        m_MethodName: SetIsOpen
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 363993209}
+        m_TargetAssemblyTypeName: MenuManager, Assembly-CSharp
+        m_MethodName: SetStoreIsOn
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
       - m_Target: {fileID: 3291930203106343763}
         m_TargetAssemblyTypeName: 
         m_MethodName: nextDay

--- a/Space-Zoologist/Assets/Scripts/Notebook/UI/DrawingCanvas.cs
+++ b/Space-Zoologist/Assets/Scripts/Notebook/UI/DrawingCanvas.cs
@@ -72,8 +72,11 @@ public class DrawingCanvas : MonoBehaviour,  IBeginDragHandler, IDragHandler
     {
         if(drawingTexture != null)
         {
+            // SummaryManager is backend, should not be used in editor
             SummaryManager summaryManager = (SummaryManager)FindObjectOfType(typeof(SummaryManager));
-            summaryManager.CurrentSummaryTrace.NumDrawToolUsed += 1;
+            if(summaryManager)
+                summaryManager.CurrentSummaryTrace.NumDrawToolUsed += 1;
+            
             previousTexturePosition = MousePositionToPositionInTexture(data.position);
 
             // Fill a circle as the cap of this line

--- a/Space-Zoologist/Assets/Scripts/Notebook/UI/NotebookUI.cs
+++ b/Space-Zoologist/Assets/Scripts/Notebook/UI/NotebookUI.cs
@@ -168,12 +168,12 @@ public class NotebookUI : MonoBehaviour
         {
             if (isOpen)
             {
-                GameManager.Instance.TryToPause("Notebook");
+                //GameManager.Instance.TryToPause("Notebook");
                 AudioManager.instance.PlayOneShot(SFXType.NotebookOpen);                
             }               
             else
             {
-                GameManager.Instance.TryToUnpause("Notebook");
+                //GameManager.Instance.TryToUnpause("Notebook");
                 AudioManager.instance.PlayOneShot(SFXType.NotebookClose);               
             }
         }
@@ -186,6 +186,7 @@ public class NotebookUI : MonoBehaviour
         else
             onEnableInspectorToggle.Invoke(true);
     }
+    
     public void NavigateToBookmark(Bookmark bookmark)
     {
         if (!isOpen) SetIsOpen(true);

--- a/Space-Zoologist/Assets/Scripts/Plot/TileDataController.cs
+++ b/Space-Zoologist/Assets/Scripts/Plot/TileDataController.cs
@@ -543,7 +543,7 @@ public class TileDataController : MonoBehaviour
     private void UpdateUI(bool onOff)
     {
         GameManager.Instance.m_playerController.CanUseIngameControls = onOff;
-        NextDayButton.interactable = onOff;
+        //NextDayButton.interactable = onOff;
     }
     #endregion
 


### PR DESCRIPTION
Hitting next day while build menu/notebook is open will automatically close it
Update: Notebook no longer pauses when opened, and will remain open when going to the next day.