### PR TITLE
Frontend Hooks for Quiz Trace Data

### DIFF
--- a/Space-Zoologist/Assets/Scripts/Backend/Analytics/CustomCert.cs
+++ b/Space-Zoologist/Assets/Scripts/Backend/Analytics/CustomCert.cs
@@ -1,0 +1,13 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
+using UnityEngine;
+using UnityEngine.Networking;
+
+public class CustomCertificateHandler : CertificateHandler
+{
+    protected override bool ValidateCertificate(byte[] certificateData)
+    {
+        return true;
+    }
+}

--- a/Space-Zoologist/Assets/Scripts/Backend/Analytics/CustomCert.cs.meta
+++ b/Space-Zoologist/Assets/Scripts/Backend/Analytics/CustomCert.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5f24d37ce0c89124a9c758b300f0ead1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Space-Zoologist/Assets/Scripts/Backend/Analytics/GetSummaryTrace.cs
+++ b/Space-Zoologist/Assets/Scripts/Backend/Analytics/GetSummaryTrace.cs
@@ -7,14 +7,16 @@ using System.Text;
 public class GetSummaryTrace : MonoBehaviour
 {
     [SerializeField] private static string prodSummarytraceEndpoint = "https://spacezoologist.herokuapp.com/traces/summarytrace/get"; 
-    [SerializeField] private static string devSummarytraceEndpoint = "https://127.0.0.1:13756/traces/summarytrace/get";
+    [SerializeField] private static string devSummarytraceEndpoint = "https://127.0.0.1:443/traces/summarytrace/get";
 
     public static IEnumerator TryGetSummaryTrace(string playerID, System.Action<SummaryTraceResponse> callback)
     {
         WWWForm form = new WWWForm();
         form.AddField("playerID", playerID);
-        using (UnityWebRequest request = UnityWebRequest.Post(prodSummarytraceEndpoint, form))
+        using (UnityWebRequest request = UnityWebRequest.Post(devSummarytraceEndpoint, form))
         {
+            CustomCertificateHandler  certHandler = new CustomCertificateHandler();
+            request.certificateHandler = certHandler;
             var handler = request.SendWebRequest();
 
             float startTime = 0.0f;

--- a/Space-Zoologist/Assets/Scripts/Backend/Analytics/GetSummaryTrace.cs
+++ b/Space-Zoologist/Assets/Scripts/Backend/Analytics/GetSummaryTrace.cs
@@ -13,7 +13,7 @@ public class GetSummaryTrace : MonoBehaviour
     {
         WWWForm form = new WWWForm();
         form.AddField("playerID", playerID);
-        using (UnityWebRequest request = UnityWebRequest.Post(devSummarytraceEndpoint, form))
+        using (UnityWebRequest request = UnityWebRequest.Post(prodSummarytraceEndpoint, form))
         {
             CustomCertificateHandler  certHandler = new CustomCertificateHandler();
             request.certificateHandler = certHandler;

--- a/Space-Zoologist/Assets/Scripts/Backend/Analytics/QuizTrace.cs
+++ b/Space-Zoologist/Assets/Scripts/Backend/Analytics/QuizTrace.cs
@@ -17,6 +17,8 @@ public class QuizTrace
     [SerializeField] private int totalScore;
     [SerializeField] private int importantCategoriesScore;
     [SerializeField] private int unimportantCategoriesScore;
+    [SerializeField] private string[] correctQuestionsText;
+    [SerializeField] private string[] incorrectQuestionsText;
 
     public QuizTrace()
     {
@@ -29,6 +31,8 @@ public class QuizTrace
         this.totalScore = 0;
         this.importantCategoriesScore = 0;
         this.unimportantCategoriesScore = 0;
+        this.correctQuestionsText = new string[0];
+        this.incorrectQuestionsText = new string[0];
     }
 
     public QuizTrace(LevelID levelID, QuizInstance quizInstance)
@@ -42,6 +46,8 @@ public class QuizTrace
         this.totalScore = quizInstance.ItemizedScore.TotalScore;
         this.importantCategoriesScore = quizInstance.ScoreInImportantCategories;
         this.unimportantCategoriesScore = quizInstance.ScoreInUnimportantCategories;
+        this.correctQuestionsText = quizInstance.CorrectQuestionsText.ToArray();
+        this.incorrectQuestionsText = quizInstance.IncorrectQuestionsText.ToArray();
     }
 }
 

--- a/Space-Zoologist/Assets/Scripts/Backend/Analytics/QuizTrace.cs
+++ b/Space-Zoologist/Assets/Scripts/Backend/Analytics/QuizTrace.cs
@@ -1,0 +1,75 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+using UnityEngine.Networking;
+
+// An ad-hoc class meant to extract results from operations performed by code in the Quiz infrastructure. Much of this is centralizing and simplifying what is found in QuizInstance.cs (e.g. transforming into primitive data types so that it can be easily used by the backend/viewer).
+[System.Serializable]
+public class QuizTrace
+{
+    [SerializeField] private string playerID;
+    [SerializeField] private int levelNumber;
+    [SerializeField] private int enclosureNumber;
+    [SerializeField] private int questionsAnswered;
+    [SerializeField] private bool completed;
+    [SerializeField] private string grade;
+    [SerializeField] private int totalScore;
+    [SerializeField] private int importantCategoriesScore;
+    [SerializeField] private int unimportantCategoriesScore;
+
+    public QuizTrace()
+    {
+        this.playerID = "";
+        this.levelNumber = 0;
+        this.enclosureNumber = 0;
+        this.questionsAnswered = 0;
+        this.completed = false;
+        this.grade = "";
+        this.totalScore = 0;
+        this.importantCategoriesScore = 0;
+        this.unimportantCategoriesScore = 0;
+    }
+
+    public QuizTrace(LevelID levelID, QuizInstance quizInstance)
+    {
+        this.playerID = SummaryManager.Instance.CurrentSummaryTrace.PlayerID;
+        this.levelNumber = levelID.LevelNumber;
+        this.enclosureNumber = levelID.EnclosureNumber;
+        this.questionsAnswered = quizInstance.QuestionsAnswered;
+        this.completed = quizInstance.Completed;
+        this.grade = quizInstance.Grade.ToString();
+        this.totalScore = quizInstance.ItemizedScore.TotalScore;
+        this.importantCategoriesScore = quizInstance.ScoreInImportantCategories;
+        this.unimportantCategoriesScore = quizInstance.ScoreInUnimportantCategories;
+    }
+}
+
+public class QuizTraceManager : MonoBehaviour
+{
+    [SerializeField] private static string prodQuizTraceEndpoint = "https://spacezoologist.herokuapp.com/traces/quiztrace/submit"; 
+    [SerializeField] private static string devQuizTraceEndpoint = "https://127.0.0.1:13756/traces/quiztrace/submit";
+
+    public static IEnumerator TrySubmitQuizTrace(QuizTrace quizTrace)
+    {
+        string json = JsonUtility.ToJson(quizTrace);
+
+        var request = new UnityWebRequest(devQuizTraceEndpoint, "POST");
+        byte[] bodyRaw = Encoding.UTF8.GetBytes(json);
+        request.uploadHandler = (UploadHandler) new UploadHandlerRaw(bodyRaw);
+        request.downloadHandler = (DownloadHandler) new DownloadHandlerBuffer();
+        request.chunkedTransfer = false;
+        request.SetRequestHeader("Content-Type", "application/json");
+        yield return request.SendWebRequest();
+        Debug.Log("Status Code: " + request.responseCode);
+        if (request.result != UnityWebRequest.Result.Success)
+        {
+            Debug.Log(request.error);
+        }
+        else
+        {
+            Debug.Log("Request successfully sent");
+        }
+        request.Dispose();
+    }
+}

--- a/Space-Zoologist/Assets/Scripts/Backend/Analytics/QuizTrace.cs
+++ b/Space-Zoologist/Assets/Scripts/Backend/Analytics/QuizTrace.cs
@@ -4,7 +4,7 @@ using System.Text;
 using UnityEngine;
 using UnityEngine.Networking;
 
-// An ad-hoc class meant to extract results from operations performed by code in the Quiz infrastructure. Much of this is centralizing and simplifying what is found in QuizInstance.cs (e.g. transforming into primitive data types so that it can be easily used by the backend/viewer).
+// An class meant to extract results from operations performed by code in the Quiz infrastructure. Much of this is centralizing and simplifying what is found in QuizInstance.cs (e.g. transforming into primitive data types so that it can be easily used by the backend/viewer).
 [System.Serializable]
 public class QuizTrace
 {
@@ -60,7 +60,7 @@ public class QuizTraceManager : MonoBehaviour
     {
         string json = JsonUtility.ToJson(quizTrace);
 
-        var request = new UnityWebRequest(devQuizTraceEndpoint, "POST");
+        var request = new UnityWebRequest(prodQuizTraceEndpoint, "POST");
         CustomCertificateHandler  certHandler = new CustomCertificateHandler();
         request.certificateHandler = certHandler;
         byte[] bodyRaw = Encoding.UTF8.GetBytes(json);

--- a/Space-Zoologist/Assets/Scripts/Backend/Analytics/QuizTrace.cs
+++ b/Space-Zoologist/Assets/Scripts/Backend/Analytics/QuizTrace.cs
@@ -48,13 +48,15 @@ public class QuizTrace
 public class QuizTraceManager : MonoBehaviour
 {
     [SerializeField] private static string prodQuizTraceEndpoint = "https://spacezoologist.herokuapp.com/traces/quiztrace/submit"; 
-    [SerializeField] private static string devQuizTraceEndpoint = "https://127.0.0.1:13756/traces/quiztrace/submit";
+    [SerializeField] private static string devQuizTraceEndpoint = "https://127.0.0.1:443/traces/quiztrace/submit";
 
     public static IEnumerator TrySubmitQuizTrace(QuizTrace quizTrace)
     {
         string json = JsonUtility.ToJson(quizTrace);
 
         var request = new UnityWebRequest(devQuizTraceEndpoint, "POST");
+        CustomCertificateHandler  certHandler = new CustomCertificateHandler();
+        request.certificateHandler = certHandler;
         byte[] bodyRaw = Encoding.UTF8.GetBytes(json);
         request.uploadHandler = (UploadHandler) new UploadHandlerRaw(bodyRaw);
         request.downloadHandler = (DownloadHandler) new DownloadHandlerBuffer();

--- a/Space-Zoologist/Assets/Scripts/Backend/Analytics/QuizTrace.cs.meta
+++ b/Space-Zoologist/Assets/Scripts/Backend/Analytics/QuizTrace.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 28a5245732e9055448109f46da7ff9a5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Space-Zoologist/Assets/Scripts/Backend/Analytics/SetTrace.cs
+++ b/Space-Zoologist/Assets/Scripts/Backend/Analytics/SetTrace.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 
 // A data class containing information about a given set from a level.
+// NOTE: I am not sure set traces are being meaningfully used anymore, but I am leaving this code here in case it needs to be revisited at some point in the future.
 [System.Serializable]
 public class SetTrace
 {

--- a/Space-Zoologist/Assets/Scripts/Backend/Analytics/SubmitSummaryTrace.cs
+++ b/Space-Zoologist/Assets/Scripts/Backend/Analytics/SubmitSummaryTrace.cs
@@ -11,7 +11,7 @@ public class SubmitSummaryTrace : MonoBehaviour
 
     public static IEnumerator TrySubmitSummaryTrace(string json)
     {
-        var request = new UnityWebRequest(devSummarytraceEndpoint, "POST");
+        var request = new UnityWebRequest(prodSummarytraceEndpoint, "POST");
         CustomCertificateHandler  certHandler = new CustomCertificateHandler();
         request.certificateHandler = certHandler;
         byte[] bodyRaw = Encoding.UTF8.GetBytes(json);

--- a/Space-Zoologist/Assets/Scripts/Backend/Analytics/SubmitSummaryTrace.cs
+++ b/Space-Zoologist/Assets/Scripts/Backend/Analytics/SubmitSummaryTrace.cs
@@ -7,11 +7,13 @@ using System.Text;
 public class SubmitSummaryTrace : MonoBehaviour
 {
     [SerializeField] private static string prodSummarytraceEndpoint = "https://spacezoologist.herokuapp.com/traces/summarytrace/submit"; 
-    [SerializeField] private static string devSummarytraceEndpoint = "https://127.0.0.1:13756/traces/summarytrace/submit";
+    [SerializeField] private static string devSummarytraceEndpoint = "https://127.0.0.1:443/traces/summarytrace/submit";
 
     public static IEnumerator TrySubmitSummaryTrace(string json)
     {
-        var request = new UnityWebRequest(prodSummarytraceEndpoint, "POST");
+        var request = new UnityWebRequest(devSummarytraceEndpoint, "POST");
+        CustomCertificateHandler  certHandler = new CustomCertificateHandler();
+        request.certificateHandler = certHandler;
         byte[] bodyRaw = Encoding.UTF8.GetBytes(json);
         request.uploadHandler = (UploadHandler) new UploadHandlerRaw(bodyRaw);
         request.downloadHandler = (DownloadHandler) new DownloadHandlerBuffer();

--- a/Space-Zoologist/Assets/Scripts/Backend/SummaryManager.cs
+++ b/Space-Zoologist/Assets/Scripts/Backend/SummaryManager.cs
@@ -11,6 +11,7 @@ public class SummaryManager : MonoBehaviour
     #region Private Fields
     // Initialize the instance of this SummaryManager to null.
     private static SummaryManager instance = null;
+    public static SummaryManager Instance => instance;
     // Initialize the current SummaryTrace object.
     private SummaryTrace currentSummaryTrace = null;
     // Initialize current level, set, and set trace.

--- a/Space-Zoologist/Assets/Scripts/Quiz/QuizConversation.cs
+++ b/Space-Zoologist/Assets/Scripts/Quiz/QuizConversation.cs
@@ -135,6 +135,10 @@ public class QuizConversation : MonoBehaviour
                 // Set the quiz on the reports data to the quiz that we just finished
                 GameManager.Instance.NotebookUI.Data.Reports.SetQuiz(LevelID.Current(), currentQuiz);
 
+                // Generate the quiz trace to be sent to the backend
+                QuizTrace quizTrace = new QuizTrace(LevelID.Current(), currentQuiz);
+                QuizTraceManager.TrySubmitQuizTrace(quizTrace);
+
                 // Invoke the quiz conversation ended event when the response is over
                 currentResponse.OnConversationEnded(() => onConversationEnded.Invoke(CurrentQuiz.Grade));
             }

--- a/Space-Zoologist/Assets/Scripts/Quiz/QuizConversation.cs
+++ b/Space-Zoologist/Assets/Scripts/Quiz/QuizConversation.cs
@@ -135,9 +135,11 @@ public class QuizConversation : MonoBehaviour
                 // Set the quiz on the reports data to the quiz that we just finished
                 GameManager.Instance.NotebookUI.Data.Reports.SetQuiz(LevelID.Current(), currentQuiz);
 
-                // Generate the quiz trace to be sent to the backend
+                // Generate the quiz trace to be sent to the backend, and send it
+                Debug.Log("Generating quiz trace...");
                 QuizTrace quizTrace = new QuizTrace(LevelID.Current(), currentQuiz);
-                QuizTraceManager.TrySubmitQuizTrace(quizTrace);
+                Debug.Log(quizTrace);
+                StartCoroutine(QuizTraceManager.TrySubmitQuizTrace(quizTrace));
 
                 // Invoke the quiz conversation ended event when the response is over
                 currentResponse.OnConversationEnded(() => onConversationEnded.Invoke(CurrentQuiz.Grade));

--- a/Space-Zoologist/Assets/Scripts/Quiz/QuizInstance.cs
+++ b/Space-Zoologist/Assets/Scripts/Quiz/QuizInstance.cs
@@ -16,6 +16,8 @@ public class QuizInstance
     public ItemizedQuizScore ItemizedScore => ComputeItemizedScore(runtimeTemplate, answers);
     public int ScoreInImportantCategories => ComputeScoreInImportantCategories(runtimeTemplate, answers);
     public int ScoreInUnimportantCategories => ComputeScoreInUnimportantCategories(runtimeTemplate, answers);
+    public List<string> CorrectQuestionsText => ComputeCorrectQuestions(runtimeTemplate, answers);
+    public List<string> IncorrectQuestionsText => ComputeIncorrectQuestions(runtimeTemplate, answers);
     #endregion
 
     #region Private Editor Fields
@@ -151,6 +153,60 @@ public class QuizInstance
         }
 
         return itemizedScore;
+    }
+
+    public static List<string> ComputeCorrectQuestions(QuizRuntimeTemplate runtimeTemplate, int[] answers)
+    {
+        Debug.Log("ComputeCorrectQuestions");
+        List<string> correctQuestions = new List<string>();
+
+        for (int i = 0; i < runtimeTemplate.Questions.Length; i++)
+        {
+            // Get the current question and answer
+            QuizQuestion question = runtimeTemplate.Questions[i];
+            int answer = answers[i];
+
+            // If the answer is within range of the options 
+            // and the weight is > 0 then add the question to the list
+            if (answer >= 0 && answer < question.Options.Length)
+            {
+                QuizOption option = question.Options[answer];
+                if (option.Weight > 0)
+                {
+                    correctQuestions.Add(question.Question);
+                    Debug.Log("Correct Question: " + question.Question);
+                }
+            }
+        }
+
+        return correctQuestions;
+    }
+
+    public static List<string> ComputeIncorrectQuestions(QuizRuntimeTemplate runtimeTemplate, int[] answers)
+    {
+        Debug.Log("ComputeIncorrectQuestions");
+        List<string> incorrectQuestions = new List<string>();
+
+        for (int i = 0; i < runtimeTemplate.Questions.Length; i++)
+        {
+            // Get the current question and answer
+            QuizQuestion question = runtimeTemplate.Questions[i];
+            int answer = answers[i];
+
+            // If the answer is within range of the options 
+            // and the weight is <= 0 then add the question to the list
+            if (answer >= 0 && answer < question.Options.Length)
+            {
+                QuizOption option = question.Options[answer];
+                if (option.Weight <= 0)
+                {
+                    incorrectQuestions.Add(question.Question);
+                    Debug.Log("Incorrect Question: " + question.Question);
+                }
+            }
+        }
+
+        return incorrectQuestions;
     }
     #endregion
 }


### PR DESCRIPTION
This PR introduces the following changes:

1. Adds a new trace object called a QuizTrace that combines much of what is found in the QuizInstance class with player and level data, and centralizes it for ease of transmission to backend.
2. Adds a new function call during a QuizConversation that takes the current QuizInstance and packages what is needed into the corresponding QuizTrace.
3. Adds new List<String> fields, CorrectQuestionsText and IncorrectQuestionsText, computed by function calls within QuizInstance to easily sort text of all questions answered correctly/incorrectly.
4. Adds a workaround for **_local development only_** using the backend involving custom certificates (CustomCertificateHandler.cs).